### PR TITLE
Add a client for MAAP Hub

### DIFF
--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -67,14 +67,16 @@ clients:
       - stac:collection:create
       - stac:collection:update
       - stac:collection:delete
-  - clientId: jupyterhub-maap-staging
-    name: MAAP JupyterHub (Staging)
-    rootUrl: https://staging.hub.maap.2i2c.cloud/
-    secret: $(env:JUPYTERHUB_MAAP_STAGING_CLIENT_SECRET)
+  - clientId: jupyterhub-maap
+    name: MAAP JupyterHub
+    # Staging JupyterHub is at https://staging.hub.maap.2i2c.cloud/
+    # Prod JupyterHub is at https://hub.maap.2i2c.cloud/
+    rootUrl: $(env:JUPYTERHUB_MAAP_URL)
+    secret: $(env:JUPYTERHUB_MAAP_CLIENT_SECRET)
     publicClient: false
     attributes: {}
     redirectUris:
-      -  https://staging.hub.maap.2i2c.cloud/hub/oauth_callback
+      -  $(env:JUPYTERHUB_MAAP_URL)/hub/oauth_callback
     protocol: openid-connect
     fullScopeAllowed: true
     defaultClientScopes:
@@ -97,7 +99,7 @@ roles:
         description: Can create, update and delete STAC collections and items
       - name: Editor
         description: Can create and update STAC collections and items
-    jupyterhub-maap-staging:
+    jupyterhub-maap:
       - name: Admin
         description: Can use the JupyterHub Admin Panel
       - name: StagingAccess
@@ -120,7 +122,7 @@ roles:
         description: Access to T4 GPU instances (1 T4 GPU)
 
 clientScopeMappings:
-  jupyterhub-maap-staging:
+  jupyterhub-maap:
     - clientScope: jupyterhub:admin
       roles:
         - Admin

--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -102,6 +102,8 @@ roles:
     jupyterhub-maap-staging:
       - name: Admin
         description: Can use the JupyterHub Admin Panel
+      - name: StagingAccess
+        description: Can access staging JupyterHubs
       - name: CPU:XS
         description: Access to extra small instances (~1.9GB RAM)
       - name: CPU:S
@@ -148,6 +150,9 @@ clientScopeMappings:
     - clientScope: jupyterhub:gpu:t4
       roles:
         - GPU:T4
+    - clientScope: jupyterhub:staging
+      roles:
+        - StagingAccess
   stac:
     - clientScope: stac:item:create
       roles:
@@ -219,6 +224,9 @@ clientScopes:
   - name: jupyterhub:gpu:t4
     description: Access to T4 GPU instances (1 T4 GPU)
     protocol: openid-connect
+  - name: jupyterhub:staging
+    description: Access to staging JupyterHub instances
+    protocol: openid-connect
 
 groups:
   - name: System Administrators
@@ -226,8 +234,6 @@ groups:
       grafana:
         - GrafanaAdmin
       stac:
-        - Admin
-      jupyterhub-maap-staging:
         - Admin
 
   - name: Developers
@@ -248,6 +254,7 @@ groups:
     clientRoles:
       jupyterhub-maap-staging:
         - Admin
+        - StagingAccess
 
   - name: JupyterHub MAAP User
     clientRoles:

--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -116,8 +116,8 @@ roles:
         description: Access to extra large instances (~29.7GB RAM)
       - name: CPU:XXL
         description: Access to extra extra large instances (~60.6GB RAM)
-      - name: CPU:XXL
-        description: Access to extra extra large instances (~121GB RAM)
+      - name: CPU:XXXL
+        description: Access to extra extra extra large instances (~121GB RAM)
       - name: GPU:T4
         description: Access to T4 GPU instances (1 T4 GPU)
 

--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -102,12 +102,52 @@ roles:
     jupyterhub-maap-staging:
       - name: Admin
         description: Can use the JupyterHub Admin Panel
-      - name: CPUUser
-        description: Regular user who can access *all* CPU instances
-      - name: GPUUser
-        description: Regular user who can access *all* GPU instances
+      - name: CPU:XS
+        description: Access to extra small instances (~1.9GB RAM)
+      - name: CPU:S
+        description: Access to small instances (~3.7GB RAM)
+      - name: CPU:M
+        description: Access to medium instances (~7.4GB RAM)
+      - name: CPU:L
+        description: Access to large instances (~14.8GB RAM)
+      - name: CPU:XL
+        description: Access to extra large instances (~29.7GB RAM)
+      - name: CPU:XXL
+        description: Access to extra extra large instances (~60.6GB RAM)
+      - name: CPU:XXL
+        description: Access to extra extra large instances (~121GB RAM)
+      - name: GPU:T4
+        description: Access to T4 GPU instances (1 T4 GPU)
 
 clientScopeMappings:
+  jupyterhub-maap-staging:
+    - clientScope: jupyterhub:admin
+      roles:
+        - Admin
+    - clientScope: jupyterhub:cpu:xs
+      roles:
+        - CPU:XS
+    - clientScope: jupyterhub:cpu:s
+      roles:
+        - CPU:S
+    - clientScope: jupyterhub:cpu:m
+      roles:
+        - CPU:M
+    - clientScope: jupyterhub:cpu:l
+      roles:
+        - CPU:L
+    - clientScope: jupyterhub:cpu:xl
+      roles:
+        - CPU:XL
+    - clientScope: jupyterhub:cpu:xxl
+      roles:
+        - CPU:XXL
+    - clientScope: jupyterhub:cpu:xxxl
+      roles:
+        - CPU:XXXL
+    - clientScope: jupyterhub:gpu:t4
+      roles:
+        - GPU:T4
   stac:
     - clientScope: stac:item:create
       roles:
@@ -152,6 +192,33 @@ clientScopes:
   - name: stac:collection:delete
     description: Delete STAC collections
     protocol: openid-connect
+  - name: jupyterhub:admin
+    description: Access JupyterHub Admin Interface
+    protocol: openid-connect
+  - name: jupyterhub:cpu:xs
+    description: Access to extra small instances (~1.9GB RAM)
+    protocol: openid-connect
+  - name: jupyterhub:cpu:s
+    description: Access to small instances (~3.7GB RAM)
+    protocol: openid-connect
+  - name: jupyterhub:cpu:m
+    description: Access to medium instances (~7.4GB RAM)
+    protocol: openid-connect
+  - name: jupyterhub:cpu:l
+    description: Access to large instances (~14.8GB RAM)
+    protocol: openid-connect
+  - name: jupyterhub:cpu:xl
+    description: Access to extra large instances (~29.7GB RAM)
+    protocol: openid-connect
+  - name: jupyterhub:cpu:xxl
+    description: Access to extra extra large instances (~60.6GB RAM)
+    protocol: openid-connect
+  - name: jupyterhub:cpu:xxxl
+    description: Access to extra extra large instances (~121GB RAM)
+    protocol: openid-connect
+  - name: jupyterhub:gpu:t4
+    description: Access to T4 GPU instances (1 T4 GPU)
+    protocol: openid-connect
 
 groups:
   - name: System Administrators
@@ -169,9 +236,6 @@ groups:
         - Editor
       stac:
         - Admin
-      jupyterhub-maap-staging:
-        - CPUUsers
-        - GPUUsers
 
   - name: Data Editors
     clientRoles:
@@ -179,6 +243,28 @@ groups:
         - Viewer
       stac:
         - Editor
+
+  - name: JupyterHub MAAP Admin
+    clientRoles:
+      jupyterhub-maap-staging:
+        - Admin
+
+  - name: JupyterHub MAAP User
+    clientRoles:
+      jupyterhub-maap-staging:
+        - CPU:XS
+        - CPU:S
+        - CPU:M
+        - CPU:L
+        - CPU:XL
+        - CPU:XXL
+        - CPU:XXL
+        - CPU:XXXL
+
+  - name: JupyterHub MAAP GPU User
+    clientRoles:
+      jupyterhub-maap-staging:
+        - GPU:T4
 
 identityProviders:
   # CILogon

--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -74,9 +74,7 @@ clients:
     publicClient: false
     attributes: {}
     redirectUris:
-      -  https://staging.hub.maap.2i2c.cloud/*
-    webOrigins:
-      -  https://staging.hub.maap.2i2c.cloud
+      -  https://staging.hub.maap.2i2c.cloud/hub/oauth_callback
     protocol: openid-connect
     fullScopeAllowed: true
     defaultClientScopes:

--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -67,6 +67,21 @@ clients:
       - stac:collection:create
       - stac:collection:update
       - stac:collection:delete
+  - clientId: jupyterhub-maap-staging
+    name: MAAP JupyterHub (Staging)
+    rootUrl: https://staging.hub.maap.2i2c.cloud/
+    secret: $(env:JUPYTERHUB_MAAP_STAGING_CLIENT_SECRET)
+    publicClient: false
+    attributes: {}
+    redirectUris:
+      -  https://staging.hub.maap.2i2c.cloud/*
+    webOrigins:
+      -  https://staging.hub.maap.2i2c.cloud
+    protocol: openid-connect
+    fullScopeAllowed: true
+    defaultClientScopes:
+      - basic
+      - profile
 
 roles:
   client:
@@ -84,6 +99,13 @@ roles:
         description: Can create, update and delete STAC collections and items
       - name: Editor
         description: Can create and update STAC collections and items
+    jupyterhub-maap-staging:
+      - name: Admin
+        description: Can use the JupyterHub Admin Panel
+      - name: CPUUser
+        description: Regular user who can access *all* CPU instances
+      - name: GPUUser
+        description: Regular user who can access *all* GPU instances
 
 clientScopeMappings:
   stac:
@@ -138,6 +160,8 @@ groups:
         - GrafanaAdmin
       stac:
         - Admin
+      jupyterhub-maap-staging:
+        - Admin
 
   - name: Developers
     clientRoles:
@@ -145,6 +169,9 @@ groups:
         - Editor
       stac:
         - Admin
+      jupyterhub-maap-staging:
+        - CPUUsers
+        - GPUUsers
 
   - name: Data Editors
     clientRoles:


### PR DESCRIPTION
This is the first JupyterHub client, and its design can be replicated for all further jupyterhub clients.

1. Uses one scope to control access to each size of instance, via T shirt sizes (so we can keep adding Xs). This allows new groups to be created in the future with subsets of access to instance sizes without needing any work on 2i2c side!
2. Sets up its own groups to map to specific scopes, passing through via duplicated roles (because I don't think there's a way to map scopes directly to groups)
3. Gates access to the staging hub through its own scope, so not everyone who has access to prod hub necessarily needs to have access to the staging hubs. This also allows us to re-use the same definitions across all hubs.
4. Creates one client in config, which results in two actual clients - one in the staging keycloak instance and one in the prod keycloak instance. The staging keycloak instance will be used for the maap staging hub, and the prod keycloak instance will be used for the prod hub. The URLs and changes will be present in github environment variables (not sure if the right name) made by @alukach following comments in the config code.

This requires corresponding changes in the 2i2c infrastructure.

Ref https://github.com/2i2c-org/infrastructure/issues/5754