### PR TITLE
Mark STAC client as public

### DIFF
--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -45,8 +45,7 @@ clients:
   - clientId: stac
     name: STAC Catalog
     rootUrl: $(env:STAC_CLIENT_URL)
-    secret: $(env:STAC_CLIENT_SECRET)
-    publicClient: false
+    publicClient: true
     attributes: {}
     redirectUris:
       - $(env:STAC_CLIENT_URL)/*


### PR DESCRIPTION
The reason that PKCE was failing was that we had mistakenly marked the STAC client as _not_ public, meaning that the Client Secret was required to be provided when authenticating.  However, we do now want to require the Client Secret to be provided as we want authentication to work from thin frontend applications (eg STAC Manager, Swagger UI).  For this reason, we mark the client as public.