### PR TITLE
fix: use roles rather than scopes for jupyterhub clients

### DIFF
--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -182,7 +182,6 @@ clientScopeMappings:
     - clientScope: stac:collection:delete
       roles:
         - Admin
-        - Editor
 
 clientScopes:
   - name: stac:item:create

--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -77,21 +77,23 @@ clients:
     publicClient: false
     attributes: {}
     redirectUris:
-      -  $(env:JUPYTERHUB_MAAP_CLIENT_URL)/hub/oauth_callback
+      - $(env:JUPYTERHUB_MAAP_CLIENT_URL)/hub/oauth_callback
     protocol: openid-connect
     fullScopeAllowed: true
     defaultClientScopes: &jupyterhub-default-client-scopes
       - basic
       - profile
-      - jupyterhub:admin
-      - jupyterhub:cpu:xs
-      - jupyterhub:cpu:s
-      - jupyterhub:cpu:m
-      - jupyterhub:cpu:l
-      - jupyterhub:cpu:xl
-      - jupyterhub:cpu:xxl
-      - jupyterhub:cpu:xxxl
-      - jupyterhub:gpu:t4
+    protocolMappers:
+      - name: client-roles-claim
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-client-role-mapper
+        config:
+          access.token.claim: "true"
+          claim.name: roles
+          jsonType.label: String
+          multivalued: "true"
+          usermodel.clientRoleMapping.clientId: jupyterhub-maap
+          usermodel.clientRoleMapping.rolePrefix: ""
 
   - clientId: jupyterhub-disasters
     name: Disasters JupyterHub
@@ -102,10 +104,21 @@ clients:
     publicClient: false
     attributes: {}
     redirectUris:
-      -  $(env:JUPYTERHUB_DISASTERS_CLIENT_URL)/hub/oauth_callback
+      - $(env:JUPYTERHUB_DISASTERS_CLIENT_URL)/hub/oauth_callback
     protocol: openid-connect
     fullScopeAllowed: true
     defaultClientScopes: *jupyterhub-default-client-scopes
+    protocolMappers:
+      - name: client-roles-claim
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-client-role-mapper
+        config:
+          access.token.claim: "true"
+          claim.name: roles
+          jsonType.label: String
+          multivalued: "true"
+          usermodel.clientRoleMapping.clientId: jupyterhub-disasters
+          usermodel.clientRoleMapping.rolePrefix: ""
 
 roles:
   client:
@@ -145,35 +158,6 @@ roles:
     jupyterhub-disasters: *jupyterhub-roles
 
 clientScopeMappings:
-  jupyterhub-maap: &jupyterhub-client-scope-mappings
-    - clientScope: jupyterhub:admin
-      roles:
-        - Admin
-    - clientScope: jupyterhub:cpu:xs
-      roles:
-        - CPU:XS
-    - clientScope: jupyterhub:cpu:s
-      roles:
-        - CPU:S
-    - clientScope: jupyterhub:cpu:m
-      roles:
-        - CPU:M
-    - clientScope: jupyterhub:cpu:l
-      roles:
-        - CPU:L
-    - clientScope: jupyterhub:cpu:xl
-      roles:
-        - CPU:XL
-    - clientScope: jupyterhub:cpu:xxl
-      roles:
-        - CPU:XXL
-    - clientScope: jupyterhub:cpu:xxxl
-      roles:
-        - CPU:XXXL
-    - clientScope: jupyterhub:gpu:t4
-      roles:
-        - GPU:T4
-  jupyterhub-disasters: *jupyterhub-client-scope-mappings
   stac:
     - clientScope: stac:item:create
       roles:
@@ -198,6 +182,7 @@ clientScopeMappings:
     - clientScope: stac:collection:delete
       roles:
         - Admin
+        - Editor
 
 clientScopes:
   - name: stac:item:create
@@ -217,33 +202,6 @@ clientScopes:
     protocol: openid-connect
   - name: stac:collection:delete
     description: Delete STAC collections
-    protocol: openid-connect
-  - name: jupyterhub:admin
-    description: Access JupyterHub Admin Interface
-    protocol: openid-connect
-  - name: jupyterhub:cpu:xs
-    description: Access to extra small instances (~1.9GB RAM)
-    protocol: openid-connect
-  - name: jupyterhub:cpu:s
-    description: Access to small instances (~3.7GB RAM)
-    protocol: openid-connect
-  - name: jupyterhub:cpu:m
-    description: Access to medium instances (~7.4GB RAM)
-    protocol: openid-connect
-  - name: jupyterhub:cpu:l
-    description: Access to large instances (~14.8GB RAM)
-    protocol: openid-connect
-  - name: jupyterhub:cpu:xl
-    description: Access to extra large instances (~29.7GB RAM)
-    protocol: openid-connect
-  - name: jupyterhub:cpu:xxl
-    description: Access to extra extra large instances (~60.6GB RAM)
-    protocol: openid-connect
-  - name: jupyterhub:cpu:xxxl
-    description: Access to extra extra large instances (~121GB RAM)
-    protocol: openid-connect
-  - name: jupyterhub:gpu:t4
-    description: Access to T4 GPU instances (1 T4 GPU)
     protocol: openid-connect
 
 groups:

--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -70,8 +70,8 @@ clients:
 
   - clientId: jupyterhub-maap
     name: MAAP JupyterHub
-    # Staging JupyterHub is at https://staging.hub.maap.2i2c.cloud/
-    # Prod JupyterHub is at https://hub.maap.2i2c.cloud/
+    # Staging JupyterHub is at https://staging.hub.maap.2i2c.cloud
+    # Prod JupyterHub is at https://hub.maap.2i2c.cloud
     rootUrl: $(env:JUPYTERHUB_MAAP_CLIENT_URL)
     secret: $(env:JUPYTERHUB_MAAP_CLIENT_SECRET)
     publicClient: false
@@ -97,8 +97,8 @@ clients:
 
   - clientId: jupyterhub-disasters
     name: Disasters JupyterHub
-    # Staging JupyterHub is at https://staging.hub.disasters.2i2c.cloud/
-    # Prod JupyterHub is at https://hub.disasters.2i2c.cloud/
+    # Staging JupyterHub is at https://staging.hub.disasters.2i2c.cloud
+    # Prod JupyterHub is at https://hub.disasters.2i2c.cloud
     rootUrl: $(env:JUPYTERHUB_DISASTERS_CLIENT_URL)
     secret: $(env:JUPYTERHUB_DISASTERS_CLIENT_SECRET)
     publicClient: false


### PR DESCRIPTION
We are currently using scopes to indicate permissions within auth tokens for Jupyterhub. For the sake of simplicity, we used common scopes across each hub deployment. However, this introduced an unintended side-effect in that if a user had access to a scope via a Client->Role->Group relationship, then they would have access to that Scope for any client. This meant that we were unable to have separate permissions across clients. By instead utilizing Roles to identify a permission, we are able to employ a the `oidc-usermodel-client-role-mapper` to inject only roles matching the client.

This alters the auth token from:

> [!IMPORTANT]
> 
> ```json
> {
>   # ...
>   "scope": "openid profile jupyterhub:cpu:xs jupyterhub:cpu:s jupyterhub:cpu:m jupyterhub:cpu:l jupyterhub:cpu:xl jupyterhub:cpu:xxl jupyterhub:cpu:xxxl",
> }
> ```
> 
> to:
> 
> ```json
> {
>   # ...
>   "scope": "openid profile",
>   "roles": [
>     "CPU:XXXL",
>     "CPU:S",
>     "CPU:XXL",
>     "CPU:XL",
>     "CPU:M",
>     "CPU:XS",
>     "CPU:L"
>   ]
> }
> ```

> [!CAUTION]
> If a user does not have access any roles associated with the client, **the token will be without a `roles` property**