### PR TITLE
Make ingest ui private

### DIFF
--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -194,7 +194,8 @@ clients:
   - clientId: ingest-ui
     name: Ingest UI
     rootUrl: $(env:INGEST_UI_CLIENT_URL)
-    publicClient: true
+    secret: $(env:INGEST_UI_CLIENT_SECRET)
+    publicClient: false
     attributes: {}
     redirectUris:
       - $(env:INGEST_UI_CLIENT_URL)/*


### PR DESCRIPTION
The [ingest-ui](https://github.com/NASA-IMPACT/veda-ingest-ui/pull/75) is using next-auth for server side auth so we need to pass the client id and secret for Authorization Code Flow.