### PR TITLE
Add IDP mappers

### DIFF
--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -447,7 +447,7 @@ identityProviders:
       issuer: "https://cilogon.org"
       useJwksUrl: "true"
       pkceEnabled: "false"
-      "defaultScope": "openid email profile",
+      defaultScope: "openid email profile",
       metadataDescriptorUrl: "https://cilogon.org/.well-known/openid-configuration"
       authorizationUrl: "https://cilogon.org/authorize"
       clientAuthMethod: "client_secret_post"

--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -447,12 +447,35 @@ identityProviders:
       issuer: "https://cilogon.org"
       useJwksUrl: "true"
       pkceEnabled: "false"
+      "defaultScope": "openid email profile",
       metadataDescriptorUrl: "https://cilogon.org/.well-known/openid-configuration"
       authorizationUrl: "https://cilogon.org/authorize"
       clientAuthMethod: "client_secret_post"
-      syncMode: "LEGACY"
+      syncMode: "IMPORT"
       clientId: $(env:CILOGON_CLIENT_ID)
       clientSecret: $(env:CILOGON_CLIENT_SECRET)
+identityProviderMappers:
+  - name: "email"
+    identityProviderAlias: cilogon
+    identityProviderMapper: oidc-user-attribute-idp-mapper
+    config:
+      syncMode: "IMPORT"
+      claim: "email"
+      user.attribute: "email"
+  - name: "first name"
+    identityProviderAlias: cilogon
+    identityProviderMapper: oidc-user-attribute-idp-mapper
+    config:
+      syncMode: "IMPORT"
+      claim: "profile.given_name"
+      user.attribute: "firstName"
+  - name: "last name"
+    identityProviderAlias: cilogon
+    identityProviderMapper: oidc-user-attribute-idp-mapper
+    config:
+      syncMode: "IMPORT"
+      claim: "profile.family_name"
+      user.attribute: "lastName"
 
 # Login Flow Configuration
 browserFlow: Browser without Password


### PR DESCRIPTION
## Description

Keycloak wasn't requesting any scopes from CI logon or mapping them so wasn't importing the required user profile attributes. That's why the form below was showing up on first login. This change skips the new user profile review step/form and automatically creates a new user based on the IDP scope attributes.
![image](https://github.com/user-attachments/assets/e92a64f8-7455-459b-a9f8-e66d3e28ed24)