### PR TITLE
Add Keycloak health checks to ECS

### DIFF
--- a/cdk/lib/keycloak/service.py
+++ b/cdk/lib/keycloak/service.py
@@ -123,6 +123,7 @@ class KeycloakService(Construct):
                     "KC_HOSTNAME": hostname,
                     "KC_HTTP_ENABLED": "true",
                     "KC_HTTP_MANAGEMENT_PORT": str(health_management_port),
+                    "KC_HEALTH_ENABLED": "true",
                 },
                 secrets={
                     # Database credentials
@@ -156,12 +157,12 @@ class KeycloakService(Construct):
 
         self.alb_service.target_group.configure_health_check(
             path="/health",
-            port=str(health_management_port),  # "9000"
+            port=str(health_management_port),  # 9000
             protocol=elbv2.Protocol.HTTP,
             healthy_threshold_count=3,
             unhealthy_threshold_count=2,
             timeout=Duration.seconds(5),
-            interval=Duration.seconds(30),
+            interval=Duration.seconds(60),
         )
 
         self.alb_service.service.connections.allow_from(

--- a/cdk/lib/keycloak/service.py
+++ b/cdk/lib/keycloak/service.py
@@ -147,10 +147,21 @@ class KeycloakService(Construct):
             ),
         )
 
-        # TODO: Configure health check on port 9000 with the path '/health'
+        self.alb_service.task_definition.default_container.add_port_mappings(
+            ecs.PortMapping(
+                container_port=health_management_port,  # 9000
+                protocol=ecs.Protocol.TCP,
+            )
+        )
+
         self.alb_service.target_group.configure_health_check(
-            path="/admin/master/console/",
+            path="/health",
+            port=str(health_management_port),  # "9000"
+            protocol=elbv2.Protocol.HTTP,
             healthy_threshold_count=3,
+            unhealthy_threshold_count=2,
+            timeout=Duration.seconds(5),
+            interval=Duration.seconds(30),
         )
 
         database_instance.connections.allow_default_port_from(self.alb_service.service)

--- a/cdk/lib/keycloak/service.py
+++ b/cdk/lib/keycloak/service.py
@@ -164,4 +164,10 @@ class KeycloakService(Construct):
             interval=Duration.seconds(30),
         )
 
+        self.alb_service.service.connections.allow_from(
+            load_balancer,
+            ec2.Port.tcp(health_management_port),
+            "Health check on port 9000",
+        )
+
         database_instance.connections.allow_default_port_from(self.alb_service.service)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
       ROOT_LOGLEVEL: INFO
     ports:
       - 8080:8080
+      - 9000:9000
     command:
       - start
       - --optimized
@@ -45,9 +46,8 @@ services:
       GRAFANA_CLIENT_URL: http://localhost:3000
       CILOGON_CLIENT_ID: abc13
       CILOGON_CLIENT_SECRET: abc123
-
     env_file:
-      - path: .env
+      - path: ./.env
         required: false
     restart: "no"
     develop:

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -10,4 +10,4 @@ RUN ./build_and_collect_jars.sh
 FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS keycloak
 COPY --from=builder /workspace/.jars/*.jar /opt/keycloak/providers/
 COPY themes /opt/keycloak/themes
-RUN /opt/keycloak/bin/kc.sh build
+RUN /opt/keycloak/bin/kc.sh build --health-enabled=true


### PR DESCRIPTION
Addresses #58 

Enable health check endpoints to the image build. These endpoints can be accessed on port 9000. The ECS health checks have been switched over to use these endpoints.

Tested on a temporary stack in UAH.

![image](https://github.com/user-attachments/assets/940c26f1-5864-49b9-8f3b-c9fd9004b9f1)
