### PR TITLE
Support building DB from snapshot

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -70,6 +70,7 @@ jobs:
           # Imported Identity Provider secrets
           IDP_SECRET_ARN_GH: ${{ vars.IDP_SECRET_ARN_GH }}
           IDP_SECRET_ARN_CILOGON: ${{ vars.IDP_SECRET_ARN_CILOGON }}
+          RDS_SNAPSHOT_IDENTIFIER: ${{ vars.RDS_SNAPSHOT_IDENTIFIER }}
 
       - name: Get ConfigLambdaArn from CloudFormation
         id: get-lambda-arn

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -1,0 +1,63 @@
+name: Diff CDK Stack
+
+on:
+  pull_request:
+
+permissions:
+  id-token: write # Required for OIDC authentication w/ AWS
+  contents: read
+
+run-name: Diff ${{ github.ref }}
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-session-name: GitHubActionsCDKDeploy
+          role-duration-seconds: 3600
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync -p 3.13
+
+      - name: Synthesize CDK
+        run: uv run npx cdk synth
+        env:
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          CDK_BOOTSTRAP_QUALIFIER: ${{ vars.CDK_BOOTSTRAP_QUALIFIER }}
+          VPC_ID: ${{ vars.VPC_ID }}
+          PERMISSIONS_BOUNDARY_ARN: ${{ vars.PERMISSIONS_BOUNDARY_ARN }}
+          HOSTNAME: ${{ vars.HOSTNAME }}
+          KEYCLOAK_VERSION: ${{ vars.KEYCLOAK_VERSION }}
+          KEYCLOAK_CONFIG_CLI_VERSION: ${{ vars.KEYCLOAK_CONFIG_CLI_VERSION }}
+          SSL_CERTIFICATE_ARN: ${{ vars.SSL_CERTIFICATE_ARN }}
+          STAGE: dev
+          # Imported Identity Provider secrets
+          IDP_SECRET_ARN_GH: ${{ vars.IDP_SECRET_ARN_GH }}
+          IDP_SECRET_ARN_CILOGON: ${{ vars.IDP_SECRET_ARN_CILOGON }}
+
+      - name: Diff CDK
+        uses: corymhall/cdk-diff-action@v2
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -52,6 +52,7 @@ jobs:
           KEYCLOAK_VERSION: ${{ vars.KEYCLOAK_VERSION }}
           KEYCLOAK_CONFIG_CLI_VERSION: ${{ vars.KEYCLOAK_CONFIG_CLI_VERSION }}
           SSL_CERTIFICATE_ARN: ${{ vars.SSL_CERTIFICATE_ARN }}
+          RDS_SNAPSHOT_IDENTIFIER: ${{ vars.RDS_SNAPSHOT_IDENTIFIER }}
           STAGE: dev
           # Imported Identity Provider secrets
           IDP_SECRET_ARN_GH: ${{ vars.IDP_SECRET_ARN_GH }}

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -73,6 +73,7 @@ KeycloakStack(
     idp_oauth_client_secrets=idp_oauth_client_secrets,
     private_oauth_clients=private_oauth_clients,
     is_production=settings.is_production,
+    rds_snapshot_identifier=settings.rds_snapshot_identifier,
     # Stack Configuration
     env={
         "account": settings.aws_account_id,

--- a/cdk/lib/keycloak/database.py
+++ b/cdk/lib/keycloak/database.py
@@ -40,7 +40,6 @@ class KeycloakDatabase(Construct):
             "instance_type": ec2.InstanceType.of(
                 ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MEDIUM
             ),
-            "storage_encrypted": True,
             "removal_policy": (
                 RemovalPolicy.RETAIN if is_production else RemovalPolicy.DESTROY
             ),
@@ -52,6 +51,7 @@ class KeycloakDatabase(Construct):
             rds.DatabaseInstance(
                 self,
                 "KeycloakPostgres",
+                storage_encrypted=True,
                 **database_instance_props,
             )
             if snapshot_identifier is None

--- a/cdk/lib/keycloak/database.py
+++ b/cdk/lib/keycloak/database.py
@@ -59,6 +59,10 @@ class KeycloakDatabase(Construct):
                 self,
                 "KeycloakPostgres",
                 snapshot_identifier=snapshot_identifier,
+                credentials=rds.SnapshotCredentials.from_generated_secret(
+                    username="admin",
+                    exclude_characters="!&*^#@()",
+                ),
                 **database_instance_props,
             )
         )

--- a/cdk/lib/keycloak/stack.py
+++ b/cdk/lib/keycloak/stack.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from aws_cdk import (
     Stack,
     aws_ec2 as ec2,
@@ -11,6 +13,7 @@ from .url import KeycloakUrl
 
 
 class KeycloakStack(Stack):
+
     def __init__(
         self,
         scope: Construct,
@@ -25,7 +28,8 @@ class KeycloakStack(Stack):
         keycloak_config_cli_app_dir: str,
         idp_oauth_client_secrets: dict,
         private_oauth_clients: list,
-        vpc_id: str = None,
+        vpc_id: Optional[str] = None,
+        rds_snapshot_identifier: Optional[str] = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -42,6 +46,7 @@ class KeycloakStack(Stack):
             vpc=vpc,
             database_name="keycloak",
             is_production=is_production,
+            snapshot_identifier=rds_snapshot_identifier,
         )
 
         kc_service = KeycloakService(

--- a/cdk/lib/settings.py
+++ b/cdk/lib/settings.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import DirectoryPath
+from pydantic import DirectoryPath, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,6 +16,10 @@ class Settings(BaseSettings):
     keycloak_app_dir: DirectoryPath = DirectoryPath("keycloak")
     keycloak_config_cli_version: str = "latest-26"
     keycloak_config_cli_app_dir: DirectoryPath = DirectoryPath("keycloak-config-cli")
+    rds_snapshot_identifier: Optional[str] = Field(
+        default=None,
+        pattern=r"^arn:aws:rds:[a-z0-9-]+:\d{12}:snapshot:.+$",
+    )
 
     model_config = SettingsConfigDict(extra="ignore")
 
@@ -26,6 +30,3 @@ class Settings(BaseSettings):
     @property
     def keycloak_config_cli_config_dir(self):
         return self.keycloak_config_cli_app_dir / "config"
-
-
-import os

--- a/cdk/lib/settings.py
+++ b/cdk/lib/settings.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import DirectoryPath, Field
+from pydantic import DirectoryPath, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -20,6 +20,13 @@ class Settings(BaseSettings):
         default=None,
         pattern=r"^arn:aws:rds:[a-z0-9-]+:\d{12}:snapshot:.+$",
     )
+
+    @field_validator("rds_snapshot_identifier", mode="before")
+    @classmethod
+    def convert_empty_string_to_none(cls, v):
+        if v == "":
+            return None
+        return v
 
     model_config = SettingsConfigDict(extra="ignore")
 


### PR DESCRIPTION
## What I'm Changing

We want to encrypt the current production Keycloak DB.  However, this is not possible on an existing deployment[^1]. As such, we should support building a DB from a snapshot to allow us to swap out our deployed DB that lacks encrypted storage with on with encrypted storage.

## How I did it

Support a new `rds_snapshot_identifier` setting to allow a user to pass in a snapshot arn. If provided, a `DatabaseInstanceFromSnapshot` construct is used rather than `DatabaseInstance`.

[^1]: https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/encrypt-an-existing-amazon-rds-for-postgresql-db-instance.html