### PR TITLE
fix(url): route 53 record configuration is optional

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -71,6 +71,7 @@ jobs:
           IDP_SECRET_ARN_GH: ${{ vars.IDP_SECRET_ARN_GH }}
           IDP_SECRET_ARN_CILOGON: ${{ vars.IDP_SECRET_ARN_CILOGON }}
           RDS_SNAPSHOT_IDENTIFIER: ${{ vars.RDS_SNAPSHOT_IDENTIFIER }}
+          CONFIGURE_ROUTE53: ${{ vars.CONFIGURE_ROUTE53 }}
 
       - name: Get ConfigLambdaArn from CloudFormation
         id: get-lambda-arn

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -62,4 +62,5 @@ jobs:
       - name: Diff CDK
         uses: corymhall/cdk-diff-action@v2
         with:
+          failOnDestructiveChanges: false
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -54,6 +54,7 @@ jobs:
           SSL_CERTIFICATE_ARN: ${{ vars.SSL_CERTIFICATE_ARN }}
           RDS_SNAPSHOT_IDENTIFIER: ${{ vars.RDS_SNAPSHOT_IDENTIFIER }}
           STAGE: dev
+          CONFIGURE_ROUTE53: ${{ vars.CONFIGURE_ROUTE53 }}
           # Imported Identity Provider secrets
           IDP_SECRET_ARN_GH: ${{ vars.IDP_SECRET_ARN_GH }}
           IDP_SECRET_ARN_CILOGON: ${{ vars.IDP_SECRET_ARN_CILOGON }}

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -72,6 +72,7 @@ KeycloakStack(
     keycloak_config_cli_app_dir=settings.keycloak_config_cli_app_dir.as_posix(),
     idp_oauth_client_secrets=idp_oauth_client_secrets,
     private_oauth_clients=private_oauth_clients,
+    configure_route53=settings.configure_route53,
     is_production=settings.is_production,
     rds_snapshot_identifier=settings.rds_snapshot_identifier,
     # Stack Configuration

--- a/cdk/lib/keycloak/stack.py
+++ b/cdk/lib/keycloak/stack.py
@@ -28,9 +28,9 @@ class KeycloakStack(Stack):
         keycloak_config_cli_app_dir: str,
         idp_oauth_client_secrets: dict,
         private_oauth_clients: list,
+        configure_route53: bool,
         vpc_id: Optional[str] = None,
         rds_snapshot_identifier: Optional[str] = None,
-        configure_route53: Optional[bool] = False,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)

--- a/cdk/lib/keycloak/stack.py
+++ b/cdk/lib/keycloak/stack.py
@@ -30,7 +30,7 @@ class KeycloakStack(Stack):
         private_oauth_clients: list,
         vpc_id: Optional[str] = None,
         rds_snapshot_identifier: Optional[str] = None,
-        configure_route53: Optional[bool] = None,
+        configure_route53: Optional[bool] = False,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)

--- a/cdk/lib/keycloak/stack.py
+++ b/cdk/lib/keycloak/stack.py
@@ -87,4 +87,4 @@ class KeycloakStack(Stack):
                 alb=kc_service.alb_service.load_balancer,
             )
         else:
-            print("Warning: Hostname not provided--new record for keycloak service load balancer must be added to hosted zone")
+            print("Warning: Environment is set to manual DNS configuration--new record for keycloak service load balancer must be added to hosted zone")

--- a/cdk/lib/keycloak/stack.py
+++ b/cdk/lib/keycloak/stack.py
@@ -78,9 +78,12 @@ class KeycloakStack(Stack):
             version=keycloak_config_cli_version,
         )
 
-        KeycloakUrl(
-            self,
-            "url",
-            hostname=hostname,
-            alb=kc_service.alb_service.load_balancer,
-        )
+        if hostname:
+            KeycloakUrl(
+                self,
+                "url",
+                hostname=hostname,
+                alb=kc_service.alb_service.load_balancer,
+            )
+        else:
+            print("Warning: Hostname not provided--new record for keycloak service load balancer must be added to hosted zone")

--- a/cdk/lib/keycloak/stack.py
+++ b/cdk/lib/keycloak/stack.py
@@ -30,6 +30,7 @@ class KeycloakStack(Stack):
         private_oauth_clients: list,
         vpc_id: Optional[str] = None,
         rds_snapshot_identifier: Optional[str] = None,
+        configure_route53: Optional[bool] = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -78,7 +79,7 @@ class KeycloakStack(Stack):
             version=keycloak_config_cli_version,
         )
 
-        if hostname:
+        if configure_route53:
             KeycloakUrl(
                 self,
                 "url",

--- a/cdk/lib/settings.py
+++ b/cdk/lib/settings.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     vpc_id: Optional[str] = None
     permissions_boundary_arn: Optional[str] = None
     ssl_certificate_arn: str
-    hostname: Optional[str] = None
+    hostname: str
     stage: str = "dev"
     keycloak_version: str = "26.0.5"
     keycloak_app_dir: DirectoryPath = DirectoryPath("keycloak")

--- a/cdk/lib/settings.py
+++ b/cdk/lib/settings.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
         default=None,
         pattern=r"^arn:aws:rds:[a-z0-9-]+:\d{12}:snapshot:.+$",
     )
+    configure_route53: Optional[bool] = True
 
     @field_validator("rds_snapshot_identifier", mode="before")
     @classmethod

--- a/cdk/lib/settings.py
+++ b/cdk/lib/settings.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     vpc_id: Optional[str] = None
     permissions_boundary_arn: Optional[str] = None
     ssl_certificate_arn: str
-    hostname: str
+    hostname: Optional[str] = None
     stage: str = "dev"
     keycloak_version: str = "26.0.5"
     keycloak_app_dir: DirectoryPath = DirectoryPath("keycloak")


### PR DESCRIPTION
## What
Route 53 record configuration is optional for cases when maintainers manually generate domain records for the keycloak service load balancer--such as instances that uses a domain in a separate AWS account.