### PR TITLE
Add discourse client

### DIFF
--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -93,7 +93,9 @@ clients:
     name: STAC Ingest API
     rootUrl: $(env:INGEST_API_CLIENT_URL)
     publicClient: true
-    attributes: {}
+    attributes: {
+      "access.token.lifespan": "3600",
+    }
     redirectUris:
       - $(env:INGEST_API_CLIENT_URL)/*
     webOrigins:


### PR DESCRIPTION
- Adds client for https://community.openveda.cloud/ (Discourse). 
- adds 60 min token lifespan for ingest api
