### PR TITLE
test: list config

### DIFF
--- a/keycloak-config-cli/config/veda.yaml
+++ b/keycloak-config-cli/config/veda.yaml
@@ -46,10 +46,8 @@ clients:
     rootUrl: $(env:STAC_CLIENT_URL)
     publicClient: true
     attributes: {}
-    redirectUris:
-      - $(env:STAC_CLIENT_URL)/*
-    webOrigins:
-      - $(env:STAC_CLIENT_URL)
+    redirectUris: [$(env:STAC_CLIENT_REDIRECTS)]
+    webOrigins: [$(env:STAC_CLIENT_ORIGINS)]
     protocol: openid-connect
     fullScopeAllowed: true
     defaultClientScopes:
@@ -147,10 +145,8 @@ clients:
     attributes: {
       "access.token.lifespan": "3600",
     }
-    redirectUris:
-      - $(env:INGEST_API_CLIENT_URL)/*
-    webOrigins:
-      - $(env:INGEST_API_CLIENT_URL)
+    redirectUris: [$(env:INGEST_API_CLIENT_REDIRECTS)]
+    webOrigins: [$(env:INGEST_API_CLIENT_ORIGINS)]
     protocol: openid-connect
     fullScopeAllowed: true
     defaultClientScopes:
@@ -241,10 +237,8 @@ clients:
     secret: $(env:INGEST_UI_CLIENT_SECRET)
     publicClient: false
     attributes: {}
-    redirectUris:
-      - $(env:INGEST_UI_CLIENT_URL)/*
-    webOrigins:
-      - $(env:INGEST_UI_CLIENT_URL)
+    redirectUris: [$(env:INGEST_UI_CLIENT_REDIRECTS)]
+    webOrigins: [$(env:INGEST_UI_CLIENT_ORIGINS)]
     protocol: openid-connect
     fullScopeAllowed: true
     defaultClientScopes:


### PR DESCRIPTION
Trying idea I mentioned earlier + leaving as draft → Alternative yaml syntax works with comma-separated inputs

In its current state it would add a lot of config overhead. Provides most flexibility between clients, but intra-realm (veda) likely doesn't need it since most clients use the same patterns. Would not necessarily apply to future additions.

We could dry it out by passing just the `X_CLIENT_URL` and intercepting within the _lambda_ to map per-env for each type, but it might be too much effort before multi-tenancy, GHGC, MAAP, etc when we'll have better intel

### What I Changed

Changed all and reverted to just the Grafana client, to minimize any possible disruption. See client config: https://keycloak.delta-backend.xyz/admin/master/console/#/veda/clients/59e05bc1-1ee9-4c77-be01-09e56032b92d/settings

### Testing

I had updated all and reverted to just the Grafana client to minimize any disruption. The previous commit can be (partially) reverted to test others. 

1. Update `GRAFANA_CLIENT_REDIRECTS` or `GRAFANA_CLIENT_ORIGINS` vars in `dev` environment
    1. Value should be a comma-separated list of URLs
1. Dispatch `dev` build
1. Verify client config: https://keycloak.delta-backend.xyz/admin/master/console/#/veda/clients/59e05bc1-1ee9-4c77-be01-09e56032b92d/settings