### PR TITLE
fix: throw hard failures on yaml parse errors

### DIFF
--- a/cdk/lib/utils.py
+++ b/cdk/lib/utils.py
@@ -54,7 +54,7 @@ def get_private_client_ids(config_dir: str) -> list[dict[str, str]]:
                         logging.warning(
                             "Missing clientId for client %s in file %s",
                             client,
-                            filename
+                            filename,
                         )
 
     # Validate each extracted clientId


### PR DESCRIPTION
As discovered in #126, when the current system fails to parse a YAML file, it simple prints a message and moves onward (ignoring that YAML file).  This means that if someone edits a yaml file and breaks it for whatever reason, CDK will not know of any content within that YAML file and subsequently attempt to delete any resources related to that YAML content (e.g. client secrets).  Rather than absorbing YAML errors, we should instead allow the yaml parse to throw its parse errors to inform reviewers of the issue.