### PR TITLE
fix: update client roles in eic tenant groups config

### DIFF
--- a/keycloak-config-cli/config/dev/eic.yaml
+++ b/keycloak-config-cli/config/dev/eic.yaml
@@ -208,11 +208,9 @@ groups:
         subGroups:
           - name: Admins
             clientRoles:
-              grafana:
-                - GrafanaAdmin
-              stac:
+              eic-stac:
                 - Admin
-              ingest-api:
+              eic-ingest-api:
                 - Admin
           - name: Editors
             clientRoles:


### PR DESCRIPTION
Change to fix https://github.com/NASA-IMPACT/veda-keycloak/actions/runs/19443689269/job/55632946849 error. 
- remove grafana client reference since this client doesn't exist in the EIC realm
- updates the stac and ingest api clients to use correct name (prefix with `eic-`)