### PR TITLE
added redirect and origin urls to ghgc-ingest-api

### DIFF
--- a/keycloak-config-cli/config/dev/ghgc.yaml
+++ b/keycloak-config-cli/config/dev/ghgc.yaml
@@ -59,7 +59,7 @@ clients:
     redirectUris:
       - https://dev.ghg.center/api/ingest/*
       - https://staging.earth.gov/ghgcenter/api/ingest/*
-      - https://earth.gov/ghgcenter/api/ingest/docs
+      - https://earth.gov/ghgcenter/api/ingest/*
     webOrigins:
       - https://dev.ghg.center
       - https://staging.earth.gov


### PR DESCRIPTION
Added Redirect urls and web origins for ghgc-ingest-api for staging and production. 