### PR TITLE
fix: add policies and permissions to UMA server

### DIFF
--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -474,7 +474,7 @@ clients:
           config:
             resources: '["stac:collection:public:*"]'
             scopes: '["create","update"]'
-            applyPolicies: '["Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
         - name: Public Collections Permission - Read
           type: scope
           logic: POSITIVE
@@ -482,7 +482,7 @@ clients:
           config:
             resources: '["stac:collection:public:*"]'
             scopes: '["read"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
         - name: Public Collections Permission - Delete
           type: scope
           logic: POSITIVE
@@ -490,7 +490,7 @@ clients:
           config:
             resources: '["stac:collection:public:*"]'
             scopes: '["delete"]'
-            applyPolicies: '["Fake Tenant 2 Admins","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins", "Fake Tenant 1 Admins", "Developers"]'
         # Public Items Permissions
         - name: Public Items Permission - Create, Update
           type: scope
@@ -499,7 +499,7 @@ clients:
           config:
             resources: '["stac:item:public:*"]'
             scopes: '["create","update"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
         - name: Public Items Permission - Read
           type: scope
           logic: POSITIVE
@@ -507,7 +507,7 @@ clients:
           config:
             resources: '["stac:item:public:*"]'
             scopes: '["read"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
         - name: Public Items Permission - Delete
           type: scope
           logic: POSITIVE
@@ -532,7 +532,7 @@ clients:
           config:
             resources: '["stac:collection:faketenant1:*"]'
             scopes: '["read"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
         - name: Tenant1 - Collections - Delete
           type: scope
           logic: POSITIVE
@@ -557,7 +557,7 @@ clients:
           config:
             resources: '["stac:item:faketenant1:*"]'
             scopes: '["read"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
         - name: Tenant1 - Items - Delete
           type: scope
           logic: POSITIVE
@@ -574,7 +574,7 @@ clients:
           config:
             resources: '["stac:collection:faketenant2:*"]'
             scopes: '["create","update"]'
-            applyPolicies: '["Fake Tenant 2 Editors"]'
+            applyPolicies: '["Fake Tenant 2 Editors", "Fake Tenant 2 Admins"]'
         - name: Tenant2 - Collections - Read
           type: scope
           logic: POSITIVE
@@ -582,8 +582,8 @@ clients:
           config:
             resources: '["stac:collection:faketenant2:*"]'
             scopes: '["read"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
-        - name: Tenant2- Collections - Delete
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
+        - name: Tenant2 - Collections - Delete
           type: scope
           logic: POSITIVE
           decisionStrategy: UNANIMOUS
@@ -607,7 +607,7 @@ clients:
           config:
             resources: '["stac:item:faketenant2:*"]'
             scopes: '["read"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
         - name: Tenant2 - Items - Delete
           type: scope
           logic: POSITIVE
@@ -632,8 +632,8 @@ clients:
           config:
             resources: '["stac:collection:faketenant3:*"]'
             scopes: '["read"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
-        - name: Tenant3- Collections - Delete
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
+        - name: Tenant3 - Collections - Delete
           type: scope
           logic: POSITIVE
           decisionStrategy: UNANIMOUS
@@ -657,7 +657,7 @@ clients:
           config:
             resources: '["stac:item:faketenant3:*"]'
             scopes: '["read"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Editors","Fake Tenant 2 Editors","Data Editors","Fake Tenant 3 Editors","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
         - name: Tenant3 - Items - Delete
           type: scope
           logic: POSITIVE


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-keycloak/issues/162

https://www.keycloak.org/docs/latest/authorization_services/index.html

> Affirmative means that at least one permission must evaluate to a positive decision in order grant access to a resource and its scopes. Unanimous means that all permissions must evaluate to a positive decision in order for the final decision to be also positive. As an example, if two permissions for a same resource or scope are in conflict (one of them is granting access and the other is denying access), the permission to the resource or scope will be granted if the chosen strategy is Affirmative. Otherwise, a single deny from any permission will also deny access to the resource or scope.`