### PR TITLE
Add default no role group

### DIFF
--- a/keycloak-config-cli/config/dev/eic.yaml
+++ b/keycloak-config-cli/config/dev/eic.yaml
@@ -111,7 +111,7 @@ roles:
         description: Can create, update and delete STAC collections and items
       - name: Editor
         description: Can create and update STAC collections and items
-      - name: Inactive Role
+      - name: No Basic Role
         description: Has no permissions
 
 clientScopeMappings:
@@ -211,7 +211,7 @@ groups:
       stac:
         - Viewer
       ingest-api:
-        - Inactive Role
+        - No Basic Role
 
   - name: Tenants
     subGroups:

--- a/keycloak-config-cli/config/dev/ghgc.yaml
+++ b/keycloak-config-cli/config/dev/ghgc.yaml
@@ -115,7 +115,7 @@ roles:
         description: Can create, update and delete STAC collections and items
       - name: Editor
         description: Can create and update STAC collections and items
-      - name: Inactive Role
+      - name: No Basic Role
         description: Has no permissions
 
 clientScopeMappings:
@@ -215,7 +215,7 @@ groups:
       ghgc-stac:
         - Viewer
       ghgc-ingest-api:
-        - Inactive Role
+        - No Basic Role
 
 identityProviders:
   # CILogon

--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -359,7 +359,7 @@ roles:
         description: Can create, update and delete STAC collections and items
       - name: Editor
         description: Can create and update STAC collections and items
-      - name: Inactive Role
+      - name: No Basic Role
         description: Has no permissions
     jupyterhub-disasters:
       - name: Admin
@@ -508,8 +508,8 @@ groups:
       stac:
         - Viewer
       ingest-api:
-        - Inactive Role
-        
+        - No Basic Role
+
   - name: JupyterHub Disasters Admin
     clientRoles:
       jupyterhub-disasters:


### PR DESCRIPTION
Include default`No Basic Role` group that includes client roles that have no permission to address https://github.com/NASA-IMPACT/veda-keycloak/issues/70

Also removes unused "Login Flow Configuration"