### PR TITLE
feature: add no basic role group to prod realms

### DIFF
--- a/keycloak-config-cli/config/prod/disasters.yaml
+++ b/keycloak-config-cli/config/prod/disasters.yaml
@@ -159,6 +159,8 @@ roles:
     disasters-ingest-ui:
       - name: Editor
         description: Can initiate and update dataset ingests
+      - name: Limited Access
+        description: Has limited access to the ingest UI features
 
 clientScopeMappings:
   disasters-stac:
@@ -216,6 +218,9 @@ clientScopeMappings:
     - clientScope: dataset:update
       roles:
         - Editor
+    - clientScope: dataset:limited-access
+      roles:
+        - Limited Access
 
 clientScopes:
   - name: stac:item:create
@@ -241,6 +246,9 @@ clientScopes:
     protocol: openid-connect
   - name: dataset:update
     description: Update existing datasets
+    protocol: openid-connect
+  - name: dataset:limited-access
+    description: Limited access to the ingest UI features
     protocol: openid-connect
 
 groups:
@@ -276,7 +284,7 @@ groups:
       disasters-ingest-api:
         - No Basic Role
       disasters-ingest-ui:
-        - Editor
+        - Limited Access
 
   - name: Tenants
     subGroups:

--- a/keycloak-config-cli/config/prod/veda.yaml
+++ b/keycloak-config-cli/config/prod/veda.yaml
@@ -354,6 +354,8 @@ roles:
     ingest-ui:
       - name: Editor
         description: Can initiate and update dataset ingests
+      - name: Limited Access
+        description: Has limited access to the ingest UI features
 
 clientScopeMappings:
   stac:
@@ -411,6 +413,9 @@ clientScopeMappings:
     - clientScope: dataset:update
       roles:
         - Editor
+    - clientScope: dataset:limited-access
+      roles:
+        - Limited Access
 
 clientScopes:
   - name: stac:item:create
@@ -436,6 +441,9 @@ clientScopes:
     protocol: openid-connect
   - name: dataset:update
     description: Update existing datasets
+    protocol: openid-connect
+  - name: dataset:limited-access
+    description: Limited access to the ingest UI features
     protocol: openid-connect
 
 groups:
@@ -480,6 +488,8 @@ groups:
         - Viewer
       ingest-api:
         - No Basic Role
+      ingest-ui:
+        - Limited Access
 
   - name: JupyterHub Disasters Admin
     clientRoles:


### PR DESCRIPTION
Add `No Basic Role` group to prod VEDA and Disasters realms