### PR TITLE
fix: add authenticatorConfig to MAAP yaml

### DIFF
--- a/keycloak-config-cli/config/dev/maap.yml
+++ b/keycloak-config-cli/config/dev/maap.yml
@@ -411,3 +411,5 @@ authenticatorConfig:
   - alias: edl
     config:
       defaultProvider: edl
+  - alias: admin-login
+    config: {}

--- a/keycloak-config-cli/config/prod/maap.yml
+++ b/keycloak-config-cli/config/prod/maap.yml
@@ -405,3 +405,5 @@ authenticatorConfig:
   - alias: edl
     config:
       defaultProvider: edl
+  - alias: admin-login
+    config: {}


### PR DESCRIPTION
Add missing `authenticatorConfig` to MAAP EDL no browser auth flow. This was missing from PR https://github.com/NASA-IMPACT/veda-keycloak/pull/181

