### PR TITLE
feat: CMS client

### DIFF
--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -768,6 +768,9 @@ roles:
     ingest-ui:
       - name: Editor
         description: Can initiate and update dataset ingests
+    earth-gov-cms:
+      - name: earth-gov-cms-editors
+        description: Allow editing content for earth.gov via CMS
 
 clientScopeMappings:
   stac:


### PR DESCRIPTION
#179 

Adds CMS client + group to preprod Keycloak instance. Client config was exported (and cleaned up) to maintain fidelity to console testing.