### PR TITLE
feat: add eic prod to config and idp secrets

### DIFF
--- a/keycloak-config-cli/config/prod/eic.yaml
+++ b/keycloak-config-cli/config/prod/eic.yaml
@@ -7,12 +7,14 @@ displayNameHtml: eic
 clients:
   - clientId: eic-stac
     name: EIC STAC Catalog
-    rootUrl: https://staging.earth.gov/api/stac
+    rootUrl: https://eic.earth.gov/api/stac
     publicClient: true
     attributes: {}
     redirectUris:
+      - https://eic.earth.gov/api/stac/*
       - https://staging.earth.gov/api/stac/*
     webOrigins:
+      - https://eic.earth.gov
       - https://staging.earth.gov
     protocol: openid-connect
     fullScopeAllowed: true
@@ -53,12 +55,14 @@ clients:
 
   - clientId: eic-ingest-api
     name: EIC Ingest API
-    rootUrl: https://staging.earth.gov/api/ingest
+    rootUrl: https://eic.earth.gov/api/ingest
     publicClient: true
     attributes: {}
     redirectUris:
+      - https://eic.earth.gov/api/ingest/*
       - https://staging.earth.gov/api/ingest/*
     webOrigins:
+      - https://eic.earth.gov
       - https://staging.earth.gov
     protocol: openid-connect
     fullScopeAllowed: true


### PR DESCRIPTION
## What
Add configuration to eic-realm for URLs in production. Note that this PR replaces the staging root url with the prod url for the stac and ingest api clients (I don't think this will be a problematic change but we can revert to staging as root if preferred).

## TODO
- [ ] `APPLICATION_ROLE_ARN_EIC_PROD_AIRFLOW_INGEST_API_ETL` needs to be populated in github environment with the role of the SM2A worker role after EIC prod is deployed before this PR can be merged.
