### PR TITLE
feat: add ingest ui client to EIC

### DIFF
--- a/keycloak-config-cli/config/prod/eic.yaml
+++ b/keycloak-config-cli/config/prod/eic.yaml
@@ -135,7 +135,6 @@ clients:
           jsonType.label: String
           multivalued: "true"
           full.path: "false"
-          usermodel.clientRoleMapping.clientId: ingest-ui
           usermodel.clientRoleMapping.rolePrefix: ""
 
   - clientId: eic-airflow-webserver-fab


### PR DESCRIPTION
I believe for the EIC Ingest UI we need a unique keycloak client as well as a url like `https://ingest.eic.openveda.cloud`.  This should add the keycloak client