### PR TITLE
Add redirect to `/admin` on eath-gov-cms client

### DIFF
--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -728,6 +728,7 @@ clients:
     attributes: {}
     redirectUris:
       - https://dev.earth.gov/api/auth/callback/keycloak
+      - https://dev.earth.gov/admin/index.html
     webOrigins:
       - https://dev.earth.gov
     protocol: openid-connect


### PR DESCRIPTION
# Changes

Added a logout from tina + logout from keycloak on the client side. After logout from keycloak, we need to redirect to /admin. 

Thus, this change.