### PR TITLE
fix: add usermodel client role mapping client id for filtering roles and correct realm ids

### DIFF
--- a/keycloak-config-cli/config/prod/disasters.yaml
+++ b/keycloak-config-cli/config/prod/disasters.yaml
@@ -136,7 +136,7 @@ clients:
           jsonType.label: String
           multivalued: "true"
           full.path: "false"
-          usermodel.clientRoleMapping.clientId: ingest-ui
+          usermodel.clientRoleMapping.clientId: disasters-ingest-ui
           usermodel.clientRoleMapping.rolePrefix: ""
 
 

--- a/keycloak-config-cli/config/prod/eic.yaml
+++ b/keycloak-config-cli/config/prod/eic.yaml
@@ -136,6 +136,7 @@ clients:
           jsonType.label: String
           multivalued: "true"
           full.path: "false"
+          usermodel.clientRoleMapping.clientId: eic-ingest-ui
           usermodel.clientRoleMapping.rolePrefix: ""
 
   - clientId: eic-airflow-webserver-fab


### PR DESCRIPTION
## What
Add back client id in client role mapping and align this id with the client id for the realm's ingest ui client.