### PR TITLE
fix: prepend eic prefix to UMA resource server secret name

### DIFF
--- a/keycloak-config-cli/config/prod/eic.yaml
+++ b/keycloak-config-cli/config/prod/eic.yaml
@@ -175,7 +175,7 @@ clients:
   - clientId: eic-uma-resource-server
     name: Authorization Resource Server
     publicClient: false
-    secret: $(env:UMA_RESOURCE_SERVER_CLIENT_SECRET)
+    secret: $(env:EIC_UMA_RESOURCE_SERVER_CLIENT_SECRET)
     protocol: openid-connect
     standardFlowEnabled: false
     implicitFlowEnabled: false


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-keycloak/issues/207