### PR TITLE
fix: update clients to use full.path true explicitly, except when no custom protocol mapper is used

### DIFF
--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -189,7 +189,7 @@ clients:
           claim.name: groups
           jsonType.label: String
           multivalued: "true"
-          full.path: "false"
+          full.path: "true"
           usermodel.clientRoleMapping.clientId: ingest-api
           usermodel.clientRoleMapping.rolePrefix: ""
 
@@ -281,7 +281,7 @@ clients:
           claim.name: groups
           jsonType.label: String
           multivalued: "true"
-          full.path: "false"
+          full.path: "true"
           usermodel.clientRoleMapping.clientId: ingest-ui
           usermodel.clientRoleMapping.rolePrefix: ""
 

--- a/keycloak-config-cli/config/prod/disasters.yaml
+++ b/keycloak-config-cli/config/prod/disasters.yaml
@@ -135,7 +135,7 @@ clients:
           claim.name: groups
           jsonType.label: String
           multivalued: "true"
-          full.path: "false"
+          full.path: "true"
           usermodel.clientRoleMapping.clientId: disasters-ingest-ui
           usermodel.clientRoleMapping.rolePrefix: ""
 
@@ -276,7 +276,7 @@ groups:
         - Editor
       disasters-ingest-api:
         - Editor
-  
+
   - name: No Basic Role
     clientRoles:
       disasters-stac:

--- a/keycloak-config-cli/config/prod/eic.yaml
+++ b/keycloak-config-cli/config/prod/eic.yaml
@@ -135,7 +135,7 @@ clients:
           claim.name: groups
           jsonType.label: String
           multivalued: "true"
-          full.path: "false"
+          full.path: "true"
           usermodel.clientRoleMapping.clientId: eic-ingest-ui
           usermodel.clientRoleMapping.rolePrefix: ""
 

--- a/keycloak-config-cli/config/prod/veda.yaml
+++ b/keycloak-config-cli/config/prod/veda.yaml
@@ -187,7 +187,7 @@ clients:
           claim.name: groups
           jsonType.label: String
           multivalued: "true"
-          full.path: "false"
+          full.path: "true"
           usermodel.clientRoleMapping.clientId: ingest-api
           usermodel.clientRoleMapping.rolePrefix: ""
 
@@ -279,7 +279,7 @@ clients:
           claim.name: groups
           jsonType.label: String
           multivalued: "true"
-          full.path: "false"
+          full.path: "true"
           usermodel.clientRoleMapping.clientId: ingest-ui
           usermodel.clientRoleMapping.rolePrefix: ""
 


### PR DESCRIPTION

This PR attempts to resolve a token generation discrepancy between the Ingest UI and Ingest API