### PR TITLE
fix: add service account policies and permissions for UMA

### DIFF
--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -480,6 +480,20 @@ clients:
           config:
             groups: '[{"path":"/Data Editors","extendChildren":false}]'
             groupsClaim: ""
+        - name: Airflow STAC ETL Service Account
+          description: Airflow STAC ETL service account user policy
+          type: user
+          logic: POSITIVE
+          decisionStrategy: UNANIMOUS
+          config:
+            users: '["service-account-airflow-stac-etl"]'
+        - name: Airflow Ingest API ETL Service Account
+          description: Airflow Ingest API ETL service account user policy
+          type: user
+          logic: POSITIVE
+          decisionStrategy: UNANIMOUS
+          config:
+            users: '["service-account-airflow-ingest-api-etl"]'
         # Public Collections Permissions
         - name: Public Collections Permission - Create, Update
           type: scope
@@ -488,7 +502,7 @@ clients:
           config:
             resources: '["stac:collection:public:*"]'
             scopes: '["create","update"]'
-            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers", "Airflow STAC ETL Service Account", "Airflow Ingest API ETL Service Account"]'
         - name: Public Collections Permission - Read
           type: scope
           logic: POSITIVE
@@ -504,7 +518,7 @@ clients:
           config:
             resources: '["stac:collection:public:*"]'
             scopes: '["delete"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins", "Fake Tenant 1 Admins", "Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins", "Fake Tenant 1 Admins", "Developers", "Airflow STAC ETL Service Account", "Airflow Ingest API ETL Service Account"]'
         # Public Items Permissions
         - name: Public Items Permission - Create, Update
           type: scope
@@ -513,7 +527,7 @@ clients:
           config:
             resources: '["stac:item:public:*"]'
             scopes: '["create","update"]'
-            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins", "Fake Tenant 3 Editors", "Fake Tenant 2 Admins", "Fake Tenant 2 Editors", "Fake Tenant 1 Admins", "Fake Tenant 1 Editors", "Data Editors", "Developers", "Airflow STAC ETL Service Account", "Airflow Ingest API ETL Service Account"]'
         - name: Public Items Permission - Read
           type: scope
           logic: POSITIVE
@@ -529,7 +543,7 @@ clients:
           config:
             resources: '["stac:item:public:*"]'
             scopes: '["delete"]'
-            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Admins","Developers"]'
+            applyPolicies: '["Fake Tenant 3 Admins","Fake Tenant 2 Admins","Fake Tenant 1 Admins","Developers", "Airflow STAC ETL Service Account", "Airflow Ingest API ETL Service Account"]'
         # Tenant1 - Collections Permissions
         - name: Tenant1 - Collections - Create, Update
           type: scope

--- a/keycloak-config-cli/config/prod/eic.yaml
+++ b/keycloak-config-cli/config/prod/eic.yaml
@@ -377,6 +377,20 @@ clients:
           config:
             groups: '[{"path":"/Data Editors","extendChildren":false}]'
             groupsClaim: "groups"
+        - name: EIC Airflow STAC ETL Service Account
+          description: EIC Airflow STAC ETL service account user policy
+          type: user
+          logic: POSITIVE
+          decisionStrategy: UNANIMOUS
+          config:
+            users: '["service-account-eic-airflow-stac-etl"]'
+        - name: EIC Airflow Ingest API ETL Service Account
+          description: EIC Airflow Ingest API ETL service account user policy
+          type: user
+          logic: POSITIVE
+          decisionStrategy: UNANIMOUS
+          config:
+            users: '["service-account-eic-airflow-ingest-api-etl"]'
         # Public Collections Permissions
         - name: Public Collections Permission - Create, Update
           type: scope
@@ -385,7 +399,7 @@ clients:
           config:
             resources: '["stac:collection:public:*"]'
             scopes: '["create","update"]'
-            applyPolicies: '["Air Quality Admins", "Air Quality Editors", "Water Insight Admins", "Water Insight Editors", "VEDA Admins", "VEDA Editors", "GHGC Admins", "GHGC Editors", "Data Editors", "Developers"]'
+            applyPolicies: '["Air Quality Admins", "Air Quality Editors", "Water Insight Admins", "Water Insight Editors", "VEDA Admins", "VEDA Editors", "GHGC Admins", "GHGC Editors", "Data Editors", "Developers", "EIC Airflow STAC ETL Service Account", "EIC Airflow Ingest API ETL Service Account"]'
         - name: Public Collections Permission - Read
           type: scope
           logic: POSITIVE
@@ -401,7 +415,7 @@ clients:
           config:
             resources: '["stac:collection:public:*"]'
             scopes: '["delete"]'
-            applyPolicies: '["Air Quality Admins", "Water Insight Admins","VEDA Admins", "GHGC Admins", "Developers"]'
+            applyPolicies: '["Air Quality Admins", "Water Insight Admins","VEDA Admins", "GHGC Admins", "Developers", "EIC Airflow STAC ETL Service Account", "EIC Airflow Ingest API ETL Service Account"]'
         # Public Items Permissions
         - name: Public Items Permission - Create, Update
           type: scope
@@ -410,7 +424,7 @@ clients:
           config:
             resources: '["stac:item:public:*"]'
             scopes: '["create","update"]'
-            applyPolicies: '["Air Quality Admins", "Air Quality Editors", "Water Insight Admins", "Water Insight Editors", "VEDA Admins", "VEDA Editors", "GHGC Admins", "GHGC Editors", "Data Editors", "Developers"]'
+            applyPolicies: '["Air Quality Admins", "Air Quality Editors", "Water Insight Admins", "Water Insight Editors", "VEDA Admins", "VEDA Editors", "GHGC Admins", "GHGC Editors", "Data Editors", "Developers", "EIC Airflow STAC ETL Service Account", "EIC Airflow Ingest API ETL Service Account"]'
         - name: Public Items Permission - Read
           type: scope
           logic: POSITIVE
@@ -426,7 +440,7 @@ clients:
           config:
             resources: '["stac:item:public:*"]'
             scopes: '["delete"]'
-            applyPolicies: '["Air Quality Admins", "Water Insight Admins","VEDA Admins","GHGC Admins","Developers"]'
+            applyPolicies: '["Air Quality Admins", "Water Insight Admins","VEDA Admins","GHGC Admins","Developers", "EIC Airflow STAC ETL Service Account", "EIC Airflow Ingest API ETL Service Account"]'
         # GHGC - Collections Permissions
         - name: GHGC - Collections - Create, Update
           type: scope


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-keycloak/issues/232 


In order to properly allow service accounts like SM2A to successfully request party tokens from the resource server, we need to create policies for them and apply those policies to our public collections and items permissions for create, update, and delete. 

This came about today when @slesaad was testing triggering a workflow in SM2A dev and, in our backend, the RPT request kept being denied. 