### PR TITLE
fix: add service accounts to groups for UMA

### DIFF
--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -1066,6 +1066,8 @@ users:
     emailVerified: true
     enabled: true
     serviceAccountClientId: airflow-stac-etl
+    groups:
+      - /Data Editors
     clientRoles:
       stac:
       - Admin
@@ -1073,6 +1075,8 @@ users:
     emailVerified: true
     enabled: true
     serviceAccountClientId: airflow-ingest-api-etl
+    groups:
+      - /Data Editors
     clientRoles:
       ingest-api:
       - Admin

--- a/keycloak-config-cli/config/prod/eic.yaml
+++ b/keycloak-config-cli/config/prod/eic.yaml
@@ -991,6 +991,8 @@ users:
     emailVerified: true
     enabled: true
     serviceAccountClientId: eic-airflow-stac-etl
+    groups:
+      - /Data Editors
     clientRoles:
       eic-stac:
       - Admin
@@ -998,6 +1000,8 @@ users:
     emailVerified: true
     enabled: true
     serviceAccountClientId: eic-airflow-ingest-api-etl
+    groups:
+      - /Data Editors
     clientRoles:
       eic-ingest-api:
       - Admin


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-keycloak/issues/232

UMA RPT needs the right parameters (especially permission), the right client auth on the token POST, and policies that match how Keycloak actually resolves the subject (which for us, includes group membership). This change updates our configs to include the service accounts as users in Data Editors 