### PR TITLE
feat: add eie client to eic realm

### DIFF
--- a/keycloak-config-cli/config/prod/eic.yaml
+++ b/keycloak-config-cli/config/prod/eic.yaml
@@ -173,6 +173,33 @@ clients:
       - basic
       - email
 
+  - clientId: eie-demo-access-backend
+    rootUrl: http://k8s-eiellm-eiellmng-3bfff7cd13-5b11596fb1756b2e.elb.us-west-2.amazonaws.com
+    publicClient: true
+    attributes:
+      access.token.lifespan: "86400"
+      oauth2.device.authorization.grant.enabled: "true"
+    redirectUris:
+      - https://k8s-eiellm-eiellmng-3bfff7cd13-5b11596fb1756b2e.elb.us-west-2.amazonaws.com/*
+      - http://k8s-eiellm-eiellmng-3bfff7cd13-5b11596fb1756b2e.elb.us-west-2.amazonaws.com/*
+      - http://localhost:8000/*
+    webOrigins:
+      - https://k8s-eiellm-eiellmng-3bfff7cd13-5b11596fb1756b2e.elb.us-west-2.amazonaws.com
+      - http://k8s-eiellm-eiellmng-3bfff7cd13-5b11596fb1756b2e.elb.us-west-2.amazonaws.com
+      - http://localhost:8000
+    protocol: openid-connect
+    standardFlowEnabled: true
+    directAccessGrantsEnabled: true
+    fullScopeAllowed: true
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - eie:api
+      - basic
+      - email
+
   - clientId: eic-uma-resource-server
     name: Authorization Resource Server
     publicClient: false
@@ -763,6 +790,9 @@ clientScopes:
     protocol: openid-connect
   - name: dataset:update
     description: Update existing datasets
+    protocol: openid-connect
+  - name: eie:api
+    description: Access the EIE LLM API
     protocol: openid-connect
 
 groups:


### PR DESCRIPTION
Adds configuration for the EIE backend client under the EIC realm. A manually configured version of this client is available on the dev keycloak instance. The matching EIE tenant (#230) is not included in this PR.

This is a client for a project that is still in active development, so `localhost` references are intentional.

`oauth2.device.authorization.grant.enabled` allows CLI users to acquire a token, which is needed for EIE frontend development.