### PR TITLE
fix: service account username requirements

### DIFF
--- a/keycloak-config-cli/config/dev/ghgc.yaml
+++ b/keycloak-config-cli/config/dev/ghgc.yaml
@@ -332,21 +332,21 @@ authenticatorConfig:
       defaultProvider: cilogon
 
 users:
-  - username: service-account-airflow-webserver-fab
+  - username: service-account-ghgc-airflow-webserver-fab
     emailVerified: true
     enabled: true
     serviceAccountClientId: ghgc-airflow-webserver-fab
     clientRoles:
       ghgc-airflow-webserver-fab:
       - Dag_Launcher
-  - username: service-account-airflow-stac-etl
+  - username: service-account-ghgc-airflow-stac-etl
     emailVerified: true
     enabled: true
     serviceAccountClientId: ghgc-airflow-stac-etl
     clientRoles:
       ghgc-stac:
       - Admin
-  - username: service-account-airflow-ingest-api-etl
+  - username: service-account-ghgc-airflow-ingest-api-etl
     emailVerified: true
     enabled: true
     serviceAccountClientId: ghgc-airflow-ingest-api-etl

--- a/keycloak-config-cli/config/prod/ghgc.yaml
+++ b/keycloak-config-cli/config/prod/ghgc.yaml
@@ -129,7 +129,7 @@ clients:
           jsonType.label: String
           multivalued: "true"
           full.path: "true"
-          usermodel.clientRoleMapping.clientId: ingest-api
+          usermodel.clientRoleMapping.clientId: ghgc-ingest-api
           usermodel.clientRoleMapping.rolePrefix: ""
 
   - clientId: ghgc-airflow-ingest-api-etl
@@ -448,21 +448,21 @@ authenticatorConfig:
       defaultProvider: cilogon
 
 users:
-  - username: service-account-airflow-webserver-fab
+  - username: service-account-ghgc-airflow-webserver-fab
     emailVerified: true
     enabled: true
     serviceAccountClientId: ghgc-airflow-webserver-fab
     clientRoles:
       ghgc-airflow-webserver-fab:
       - Dag_Launcher
-  - username: service-account-airflow-stac-etl
+  - username: service-account-ghgc-airflow-stac-etl
     emailVerified: true
     enabled: true
     serviceAccountClientId: ghgc-airflow-stac-etl
     clientRoles:
       ghgc-stac:
       - Admin
-  - username: service-account-airflow-ingest-api-etl
+  - username: service-account-ghgc-airflow-ingest-api-etl
     emailVerified: true
     enabled: true
     serviceAccountClientId: ghgc-airflow-ingest-api-etl


### PR DESCRIPTION
Keycloak expects service account usernames to be shaped `service-account-<client_id>` https://github.com/adorsys/keycloak-config-cli/issues/1011#issuecomment-2653969848

- [service-account-airflow-ingest-api-etl](https://auth.openveda.cloud/admin/master/console/#/ghgc/users/5cc87dda-23b1-4128-aedb-b20eb625279e/role-mapping)
    - Is an identified 'user' 
    - Shows up in the `Users` list
    - Has the correct mapped Admin privileges
    - Is NOT associated with the ETL client
- [service-account-ghgc-airflow-ingest-api-etl](https://auth.openveda.cloud/admin/master/console/#/ghgc/users/131a7805-aa5e-4a27-bf96-f8d0b2fc06d1/role-mapping)
    - Is an identified 'user'
    - Does NOT show up in the `Users` list
    - Does NOT have the correct mapped Admin privileges
    - Is associated with the ETL client

Its unclear why this is correct in the dev realm and not in prod, possibly a manual fix during the GHGC keycloak transition out of VEDA's realm(s) to their own dev realm used with prod services.