### PR TITLE
add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "ci(deps):"


### PR DESCRIPTION
Add Dependabot config for:

- `uv` (CDK build)
- `maven` (Keycloak providers)
- `docker` (SES relay container image)
- `github-actions` (CI)

---

Currently on the default schedule, so we'd get in batches all at once, but can spread out more if that's the preference.

Also used more granular cooldown configs for major/minor version bumps on `uv` only, but can add to other package ecosystems if that's preferred as well.