### PR TITLE
ci: security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
         with:
           role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -44,11 +44,11 @@ jobs:
           role-duration-seconds: 3600
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4.9.1
         with:
           python-version: "3.13"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Install dependencies
         run: uv sync -p 3.13

--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
         with:
           role-to-assume: ${{ vars.AWS_CDK_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -31,11 +31,11 @@ jobs:
           role-duration-seconds: 3600
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4.9.1
         with:
           python-version: "3.13"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Install dependencies
         run: uv sync -p 3.13
@@ -68,7 +68,7 @@ jobs:
           APPLICATION_ROLE_ARN_GHGC_AIRFLOW_WEBSERVER_FAB: ${{ vars.APPLICATION_ROLE_ARN_GHGC_AIRFLOW_WEBSERVER_FAB }}
           APPLICATION_ROLE_ARN_GHGC_AIRFLOW_INGEST_API_ETL: ${{ vars.APPLICATION_ROLE_ARN_GHGC_AIRFLOW_INGEST_API_ETL }}
       - name: Diff CDK
-        uses: corymhall/cdk-diff-action@v2
+        uses: corymhall/cdk-diff-action@ad67041313333f7f2bd26b33f18fb134610a971e # v2.0.9
         with:
           failOnDestructiveChanges: false
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 16 * * 1" # Monday 10:30/11:30 CT
+
+permissions: read-all # Default all to readonly
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Allow upload to Security dashboard
+      id-token: write # Access GitHub's OIDC token to verify authenticity of result for publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Dependabot 
Dependabot **security** updates are already enabled, this config will automate **version** updates. We likely won't find the right alert:noise balance on the first attempt, so we should be open to further tuning.

Config covers:

- `uv` (CDK build)
- `maven` (Keycloak providers)
- `docker` (SES relay container image)
- `github-actions` (CI)

#### Schedule
Currently on the default schedule, so we'd get in batches all at once, but can spread out more if that's the preference.

#### Cooldowns
Also used more granular cooldown configs for major/minor version bumps on `uv` only, but can add to other package ecosystems if that's preferred as well. [Some suggest up to 14 days](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns), but we also had a teammember get blocked on patching.a security fix, so attempting to balance.

## Commit SHAs

Now enforced at the repository level, pinned to the versions used in the [last production workflow](https://github.com/NASA-IMPACT/veda-keycloak/actions/runs/25750169454/job/75624078089#step:1:29).

## OSSF Scoredcard

From the Open Source Security Foundation. Audits repository security posture, practices, and config.

https://scorecard.dev/
https://github.com/ossf/scorecard-action

#### Schedule

Alongside pushes to main, also runs Monday 10:30/11:30 CT to ensure consistent assessment. Time was chosen to run before Monday tagup, but can absolutely be changed.