### PR TITLE
feat: add realm admin and user manager groups, customize themes per realm

### DIFF
--- a/keycloak-config-cli/config/dev/ghgc.yaml
+++ b/keycloak-config-cli/config/dev/ghgc.yaml
@@ -2,7 +2,8 @@
 enabled: true
 realm: ghgc
 displayName: Applications
-displayNameHtml: GHGC 
+displayNameHtml: GHGC
+loginTheme: ghgc
 
 clients:
   - clientId: ghgc-stac
@@ -240,6 +241,19 @@ clientScopes:
     protocol: openid-connect
 
 groups:
+  - name: Realm Admin
+    clientRoles:
+      realm-management:
+        - realm-admin
+
+  - name: User Manager
+    clientRoles:
+      realm-management:
+        - view-realm
+        - view-users
+        - manage-users
+        - manage-groups
+
   - name: System Administrators
     clientRoles:
       ghgc-stac:

--- a/keycloak-config-cli/config/dev/ghgc.yaml
+++ b/keycloak-config-cli/config/dev/ghgc.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 realm: ghgc
-displayName: Applications
+displayName: GHGC
 displayNameHtml: GHGC
 loginTheme: ghgc
 

--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -3,6 +3,7 @@ enabled: true
 realm: veda
 displayName: Applications
 displayNameHtml: VEDA Ecosystem
+loginTheme: veda
 
 clients:
   - clientId: grafana
@@ -873,6 +874,19 @@ clientScopes:
     protocol: openid-connect
 
 groups:
+  - name: Realm Admin
+    clientRoles:
+      realm-management:
+        - realm-admin
+
+  - name: User Manager
+    clientRoles:
+      realm-management:
+        - view-realm
+        - view-users
+        - manage-users
+        - manage-groups
+
   - name: System Administrators
     clientRoles:
       grafana:

--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 realm: veda
-displayName: Applications
+displayName: VEDA
 displayNameHtml: VEDA Ecosystem
 loginTheme: veda
 

--- a/keycloak-config-cli/config/prod/veda.yaml
+++ b/keycloak-config-cli/config/prod/veda.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 realm: veda
-displayName: Applications
+displayName: VEDA
 displayNameHtml: VEDA Ecosystem
 
 clients:

--- a/keycloak-config-cli/config/prod/veda.yaml
+++ b/keycloak-config-cli/config/prod/veda.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 realm: veda
-displayName: VEDA
+displayName: Applications
 displayNameHtml: VEDA Ecosystem
 
 clients:

--- a/keycloak/themes/eic/login/messages/messages_en.properties
+++ b/keycloak/themes/eic/login/messages/messages_en.properties
@@ -1,0 +1,1 @@
+loginIdpReviewProfileTitle=Complete your EIC profile

--- a/keycloak/themes/eic/login/theme.properties
+++ b/keycloak/themes/eic/login/theme.properties
@@ -1,0 +1,5 @@
+parent=keycloak
+import=common/keycloak
+
+kcLogoIdP-github-org-check=fa fa-github
+styles=css/login.css css/update-profile.css

--- a/keycloak/themes/ghgc/login/messages/messages_en.properties
+++ b/keycloak/themes/ghgc/login/messages/messages_en.properties
@@ -1,0 +1,1 @@
+loginIdpReviewProfileTitle=Complete your GHGC profile

--- a/keycloak/themes/ghgc/login/theme.properties
+++ b/keycloak/themes/ghgc/login/theme.properties
@@ -1,0 +1,5 @@
+parent=keycloak
+import=common/keycloak
+
+kcLogoIdP-github-org-check=fa fa-github
+styles=css/login.css css/update-profile.css

--- a/keycloak/themes/veda/login/messages/messages_en.properties
+++ b/keycloak/themes/veda/login/messages/messages_en.properties
@@ -1,0 +1,1 @@
+loginIdpReviewProfileTitle=Complete your VEDA profile


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-architecture/issues/758

Keycloak defines a realm-management client that contains roles, and this PR creates groups for `Realm Admin` and `User Manager` which allow us to easily group roles together and then be able to assign those roles to individuals within realms by adding them to the group, rather than manually having to add each realm-management client role to an individual. 


This PR also makes some login theme changes so a login page has verbiage specific to a realm. 