### PR TITLE
fix: update to use query-* users and groups

### DIFF
--- a/keycloak-config-cli/config/dev/ghgc.yaml
+++ b/keycloak-config-cli/config/dev/ghgc.yaml
@@ -252,7 +252,8 @@ groups:
         - view-realm
         - view-users
         - manage-users
-        - manage-groups
+        - query-users
+        - query-groups
 
   - name: System Administrators
     clientRoles:

--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -885,7 +885,8 @@ groups:
         - view-realm
         - view-users
         - manage-users
-        - manage-groups
+        - query-users
+        - query-groups
 
   - name: System Administrators
     clientRoles:


### PR DESCRIPTION
To resolve 
```
de.adorsys.keycloak.config.exception.KeycloakRepositoryException: Cannot find client role 'manage-groups' for client 'realm-management' within realm 'ghgc'

```

I didn't realize `manage-groups` is not a role (I assumed it was since `manage-users` is one