### PR TITLE
fix: update sm2a redirect urls

### DIFF
--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -286,9 +286,13 @@ clients:
       standard.token.exchange.enabled: "false"
       oauth2.device.authorization.grant.enabled: "false"
       backchannel.logout.revoke.offline.tokens: "false"
+    # Both http and https needed during SM2A upgrade rollout (v0.21.4-dev.1 adds https redirect support).
+    # Remove http entries once all instances are upgraded.
     redirectUris:
       - http://sm2a.sit.openveda.cloud/oauth-authorized/keycloak
+      - http://sm2a.sit.openveda.cloud/auth/oauth-authorized/keycloak
       - http://sm2a.dev.openveda.cloud/oauth-authorized/keycloak
+      - https://sm2a.dev.openveda.cloud/oauth-authorized/keycloak
       - http://sm2a.staging.openveda.cloud/oauth-authorized/keycloak
     webOrigins:
       - https://sm2a.sit.openveda.cloud


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-architecture/issues/814

I would like to make this change because I don't think it's safe to rely on remembering to add these redirect urls manually, and we can clean this up once all the airflow instances have been upgraded