### PR TITLE
fix: use /auth redirect URIs for SM2A SIT and dev

### DIFF
--- a/keycloak-config-cli/config/dev/veda.yaml
+++ b/keycloak-config-cli/config/dev/veda.yaml
@@ -289,10 +289,10 @@ clients:
     # Both http and https needed during SM2A upgrade rollout (v0.21.4-dev.1 adds https redirect support).
     # Remove http entries once all instances are upgraded.
     redirectUris:
-      - http://sm2a.sit.openveda.cloud/oauth-authorized/keycloak
       - http://sm2a.sit.openveda.cloud/auth/oauth-authorized/keycloak
-      - http://sm2a.dev.openveda.cloud/oauth-authorized/keycloak
-      - https://sm2a.dev.openveda.cloud/oauth-authorized/keycloak
+      - https://sm2a.sit.openveda.cloud/auth/oauth-authorized/keycloak
+      - http://sm2a.dev.openveda.cloud/auth/oauth-authorized/keycloak
+      - https://sm2a.dev.openveda.cloud/auth/oauth-authorized/keycloak
       - http://sm2a.staging.openveda.cloud/oauth-authorized/keycloak
     webOrigins:
       - https://sm2a.sit.openveda.cloud


### PR DESCRIPTION
To pair with https://github.com/NASA-IMPACT/veda-data-airflow/pull/449 (merge these PRs together, the URL change is a byproduct of the Airflow 3 upgrade)